### PR TITLE
Only include duration and cost in email if they have been set.

### DIFF
--- a/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/email/alert/emailalert-html.ftl
+++ b/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/email/alert/emailalert-html.ftl
@@ -69,14 +69,18 @@ tr:hover {
         <th>Last Updated</th>
         <td>${opportunity.lastUpdated}</td>
     </tr>
+    <#if opportunity.duration gt 0>
     <tr>
         <th>Estimated Duration</th>
         <td>${opportunity.duration}</td>
     </tr>
+    </#if>
+    <#if opportunity.cost gt 0>
     <tr>
         <th>Estimated Cost</th>
         <td>${opportunity.cost}</td>
     </tr>
+    </#if>
 </table>
 <p>For changes to your subscription, contact <a href="mailto:${adminEmail}
 ?subject=Digital Markplace Subscription">${adminName}</a>.</p>


### PR DESCRIPTION
Seems odd to have duration and cost in the HTML alert email. Especially if they're both zero (which they usually are on the immediate alert).