### PR TITLE
#13 - Daily poll for removed opportunities - compares the fresh oppor…

### DIFF
--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/DigitalMarketplaceAlerterApplication.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/DigitalMarketplaceAlerterApplication.java
@@ -137,8 +137,8 @@ public class DigitalMarketplaceAlerterApplication extends Application<DigitalMar
 
         // Removed Opportunities
         ses.scheduleWithFixedDelay(new RemovedOpportunityPoller(fetcher, opportunityFactory, opportunityDAO),
-                1,
-                1,
-                TimeUnit.DAYS);
+                0,
+                2,
+                TimeUnit.MINUTES);
     }
 }

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/DigitalMarketplaceAlerterApplication.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/DigitalMarketplaceAlerterApplication.java
@@ -137,8 +137,8 @@ public class DigitalMarketplaceAlerterApplication extends Application<DigitalMar
 
         // Removed Opportunities
         ses.scheduleWithFixedDelay(new RemovedOpportunityPoller(fetcher, opportunityFactory, opportunityDAO),
-                0,
-                2,
-                TimeUnit.MINUTES);
+                1,
+                1,
+                TimeUnit.DAYS);
     }
 }

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/DigitalMarketplaceAlerterApplication.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/DigitalMarketplaceAlerterApplication.java
@@ -23,6 +23,9 @@ import uk.andrewgorton.digitalmarketplace.alerter.filters.AdminRequiredFeature;
 import uk.andrewgorton.digitalmarketplace.alerter.filters.LoginRequiredFeature;
 import uk.andrewgorton.digitalmarketplace.alerter.mappers.ForbiddenExceptionMapper;
 import uk.andrewgorton.digitalmarketplace.alerter.mappers.UnauthorizedExceptionMapper;
+import uk.andrewgorton.digitalmarketplace.alerter.polling.DigitalMarketplacePoller;
+import uk.andrewgorton.digitalmarketplace.alerter.polling.Fetcher;
+import uk.andrewgorton.digitalmarketplace.alerter.polling.RemovedOpportunityPoller;
 import uk.andrewgorton.digitalmarketplace.alerter.resources.*;
 import uk.andrewgorton.digitalmarketplace.alerter.tasks.CreateNewUser;
 import uk.andrewgorton.digitalmarketplace.alerter.tasks.GetHashedPasswordCommand;
@@ -111,11 +114,13 @@ public class DigitalMarketplaceAlerterApplication extends Application<DigitalMar
         environment.jersey().register(new SecurityResource(userDAO));
 
         // Pollers
+        final Fetcher fetcher = new Fetcher();
+        final OpportunityFactory opportunityFactory = new OpportunityFactory();
         ScheduledExecutorService ses = environment.lifecycle().scheduledExecutorService("dma-%3d").build();
         ses.scheduleWithFixedDelay(
                 new DigitalMarketplacePoller(
-                        new Fetcher(),
-                        new OpportunityFactory(),
+                        fetcher,
+                        opportunityFactory,
                         opportunityDAO),
                 0,
                 30,
@@ -127,5 +132,11 @@ public class DigitalMarketplaceAlerterApplication extends Application<DigitalMar
         final OpportunityToAlertMatcher opportunityToAlertMatcher = new OpportunityToAlertMatcher(opportunityDAO, alertDAO, emailAlerter);
         final EmailAlertRunner emailAlertRunner = new EmailAlertRunner(opportunityToAlertMatcher);
         ses.scheduleWithFixedDelay(emailAlertRunner, 0, 60, TimeUnit.SECONDS);
+
+        // Removed Opportunities
+        ses.scheduleWithFixedDelay(new RemovedOpportunityPoller(fetcher, opportunityFactory, opportunityDAO),
+                1,
+                1,
+                TimeUnit.DAYS);
     }
 }

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/Opportunity.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/Opportunity.java
@@ -19,6 +19,7 @@ public class Opportunity {
     private int duration;
     private long cost;
     private String OMT;
+    private boolean isRemoved;
 
     public long getId() {
         return id;
@@ -147,5 +148,13 @@ public class Opportunity {
 
     public void setOMT(String OMT) {
         this.OMT = OMT;
+    }
+
+    public void setRemoved(boolean removed) {
+        isRemoved = removed;
+    }
+
+    public boolean isRemoved() {
+        return isRemoved;
     }
 }

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/dao/OpportunityDAO.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/dao/OpportunityDAO.java
@@ -60,6 +60,9 @@ public interface OpportunityDAO {
     @SqlUpdate("update opportunity set removed = :removed where id = :id")
     void setRemoved(@Bind("removed") boolean isRemoved, @Bind("id") long id);
 
+    @SqlQuery("select * from opportunity where removed = false order by published desc")
+    List<Opportunity> findAllUnremoved();
+
     @SqlUpdate("insert into bidmanager_session (opportunity, key) values (:opportunity, :key)")
     void insertKey(@Bind("opportunity") Long opportunityId, @Bind("key") String key);
 

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/dao/OpportunityDAO.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/dao/OpportunityDAO.java
@@ -57,6 +57,9 @@ public interface OpportunityDAO {
     @SqlUpdate("update opportunity set cost = :cost where id = :id")
     void setOpportunityCost(@Bind("cost") int cost, @Bind("id") long id);
 
+    @SqlUpdate("update opportunity set removed = :removed where id = :id")
+    void setRemoved(@Bind("removed") boolean isRemoved, @Bind("id") long id);
+
     @SqlUpdate("insert into bidmanager_session (opportunity, key) values (:opportunity, :key)")
     void insertKey(@Bind("opportunity") Long opportunityId, @Bind("key") String key);
 

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/polling/DigitalMarketplacePoller.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/polling/DigitalMarketplacePoller.java
@@ -1,8 +1,10 @@
-package uk.andrewgorton.digitalmarketplace.alerter;
+package uk.andrewgorton.digitalmarketplace.alerter.polling;
 
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.andrewgorton.digitalmarketplace.alerter.Opportunity;
+import uk.andrewgorton.digitalmarketplace.alerter.OpportunityFactory;
 import uk.andrewgorton.digitalmarketplace.alerter.dao.OpportunityDAO;
 
 import java.util.ArrayList;

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/polling/Fetcher.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/polling/Fetcher.java
@@ -1,4 +1,4 @@
-package uk.andrewgorton.digitalmarketplace.alerter;
+package uk.andrewgorton.digitalmarketplace.alerter.polling;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/polling/RemovedOpportunityPoller.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/polling/RemovedOpportunityPoller.java
@@ -1,0 +1,37 @@
+package uk.andrewgorton.digitalmarketplace.alerter.polling;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.andrewgorton.digitalmarketplace.alerter.Opportunity;
+import uk.andrewgorton.digitalmarketplace.alerter.OpportunityFactory;
+import uk.andrewgorton.digitalmarketplace.alerter.dao.OpportunityDAO;
+
+import java.util.List;
+
+/**
+ * Polls the Digital Marketplace for removed opportunities
+ */
+public class RemovedOpportunityPoller implements Runnable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemovedOpportunityPoller.class);
+
+    private final Fetcher fetcher;
+    private final OpportunityFactory opportunityFactory;
+    private final OpportunityDAO opportunityDAO;
+
+
+    public RemovedOpportunityPoller(Fetcher fetcher, OpportunityFactory opportunityFactory, OpportunityDAO opportunityDAO) {
+        this.fetcher = fetcher;
+        this.opportunityFactory = opportunityFactory;
+        this.opportunityDAO = opportunityDAO;
+    }
+
+    @Override
+    public void run() {
+        List<Opportunity> opportunities = opportunityFactory.create(fetcher.run());
+        List<Opportunity> allOpen = opportunityDAO.findAllOpen();
+        allOpen.stream().filter(opp -> !opportunities.contains(opp)).forEach(opp -> {
+            opportunityDAO.setRemoved(true, opp.getId());
+            LOGGER.info("The following opportunity has been removed from the Digital Marketplace: {}", opp.getUrl());
+        });
+    }
+}

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -214,4 +214,9 @@
                                  referencedTableName="opportunity"
                                  referencedColumnNames="id"/>
     </changeSet>
+    <changeSet id="8" author="hendersonra">
+        <addColumn tableName="opportunity">
+            <column name="removed" valueBoolean="false" type="boolean" />
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/opportunity/detailview.ftl
+++ b/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/opportunity/detailview.ftl
@@ -4,6 +4,9 @@
     <title>Opportunity</title>
 </head>
 <body>
+<#if opportunity.removed??>
+<h1 style="color:red;">This opportunity has been removed from the Digital Marketplace</h1>
+</#if>
 <h1>${opportunity.title}</h1>
 <table>
     <tr>

--- a/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/DigitalMarketplacePollerTest.java
+++ b/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/DigitalMarketplacePollerTest.java
@@ -1,6 +1,8 @@
 package uk.andrewgorton.digitalmarketplace.alerter;
 
 import org.junit.Test;
+import uk.andrewgorton.digitalmarketplace.alerter.polling.DigitalMarketplacePoller;
+import uk.andrewgorton.digitalmarketplace.alerter.polling.Fetcher;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/polling/RemovedOpportunityPollerTest.java
+++ b/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/polling/RemovedOpportunityPollerTest.java
@@ -41,7 +41,7 @@ public class RemovedOpportunityPollerTest {
         Opportunity d = new Opportunity();
 
         when(factory.create(any())).thenReturn(Arrays.asList(c, d));
-        when(dao.findAllOpen()).thenReturn(Arrays.asList(a, b, c, d));
+        when(dao.findAllUnremoved()).thenReturn(Arrays.asList(a, b, c, d));
         RemovedOpportunityPoller poller = new RemovedOpportunityPoller(fetcher, factory, dao);
 
         poller.run();
@@ -59,7 +59,7 @@ public class RemovedOpportunityPollerTest {
 
         List opportunities = Arrays.asList(a, b, c, d);
         when(factory.create(any())).thenReturn(opportunities);
-        when(dao.findAllOpen()).thenReturn(opportunities);
+        when(dao.findAllUnremoved()).thenReturn(opportunities);
         RemovedOpportunityPoller poller = new RemovedOpportunityPoller(fetcher, factory, dao);
 
         poller.run();

--- a/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/polling/RemovedOpportunityPollerTest.java
+++ b/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/polling/RemovedOpportunityPollerTest.java
@@ -1,0 +1,70 @@
+package uk.andrewgorton.digitalmarketplace.alerter.polling;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.andrewgorton.digitalmarketplace.alerter.Opportunity;
+import uk.andrewgorton.digitalmarketplace.alerter.OpportunityFactory;
+import uk.andrewgorton.digitalmarketplace.alerter.dao.OpportunityDAO;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link RemovedOpportunityPoller}
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RemovedOpportunityPollerTest {
+
+    @Mock
+    private Fetcher fetcher;
+    @Mock
+    private OpportunityFactory factory;
+    @Mock
+    private OpportunityDAO dao;
+
+    @Test
+    public void ProperlyMarksRemovedOpportunities() throws Exception {
+        Opportunity a = new Opportunity();
+        a.setId(1234);
+        a.setUrl("https://digital.marketplace.com/opportunity/A");
+        Opportunity b = new Opportunity();
+        b.setId(5678);
+        b.setUrl("https://digital.marketplace.com/opportunity/B");
+        Opportunity c = new Opportunity();
+        Opportunity d = new Opportunity();
+
+        when(factory.create(any())).thenReturn(Arrays.asList(c, d));
+        when(dao.findAllOpen()).thenReturn(Arrays.asList(a, b, c, d));
+        RemovedOpportunityPoller poller = new RemovedOpportunityPoller(fetcher, factory, dao);
+
+        poller.run();
+
+        verify(dao).setRemoved(true, a.getId());
+        verify(dao).setRemoved(true, b.getId());
+    }
+
+    @Test
+    public void NoneToMarkRemoved() throws Exception {
+        Opportunity a = new Opportunity();
+        Opportunity b = new Opportunity();
+        Opportunity c = new Opportunity();
+        Opportunity d = new Opportunity();
+
+        List opportunities = Arrays.asList(a, b, c, d);
+        when(factory.create(any())).thenReturn(opportunities);
+        when(dao.findAllOpen()).thenReturn(opportunities);
+        RemovedOpportunityPoller poller = new RemovedOpportunityPoller(fetcher, factory, dao);
+
+        poller.run();
+
+        verify(dao, never()).setRemoved(eq(true), anyLong());
+    }
+
+}


### PR DESCRIPTION
Considering that this might not be the best approach. A better one may be to have a new field `lastUpdated` for an `Opportunity` which will be refreshed every time that an opportunity is updated from the `Fetcher`.

The `RemovedOpportunityPoller` will still run daily, but if `lastUpdated` is not more than `X` old, then the opportunity will be flagged as removed. This has the advantage of being a lightweight SQL query, instead of a heavy "pull all open opportunities" streaming operation.