### PR TITLE
#30 - Provide security through a central service

### DIFF
--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/dao/UserDAO.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/dao/UserDAO.java
@@ -18,6 +18,9 @@ public interface UserDAO {
     @SqlQuery("select * from user where username = :username")
     User findByUsername(@Bind("username") String username);
 
+    @SqlQuery("select * from user where email = :email")
+    User findByEmail(@Bind("email") String email);
+
     @SqlQuery("select * from user where id = :id")
     User findById(@Bind("id") Long id);
 
@@ -43,4 +46,10 @@ public interface UserDAO {
     void delete(@Bind("id") Long id);
 
     void close();
+
+    @SqlUpdate("insert into password_change_session (user, key) values (:user, :key)")
+    void insertKey(@Bind("user") Long userId, @Bind("key") String key);
+
+    @SqlQuery("select u.* from password_change_session p, user u where p.user = :user and p.key = :key")
+    User findByKey(@Bind("user") Long userId, @Bind("key") String key);
 }

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/email/EmailComposer.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/email/EmailComposer.java
@@ -6,14 +6,16 @@ import org.apache.commons.mail.HtmlEmail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.andrewgorton.digitalmarketplace.alerter.Opportunity;
+import uk.andrewgorton.digitalmarketplace.alerter.User;
 import uk.andrewgorton.digitalmarketplace.alerter.views.email.EmailViewRenderer;
 import uk.andrewgorton.digitalmarketplace.alerter.views.email.alert.AlertHtmlView;
 import uk.andrewgorton.digitalmarketplace.alerter.views.email.alert.AlertTextView;
 import uk.andrewgorton.digitalmarketplace.alerter.views.email.bid.BidManagerHtmlView;
 import uk.andrewgorton.digitalmarketplace.alerter.views.email.bid.BidManagerTextView;
+import uk.andrewgorton.digitalmarketplace.alerter.views.email.security.PasswordResetHtml;
+import uk.andrewgorton.digitalmarketplace.alerter.views.email.security.PasswordResetText;
 
 import java.io.IOException;
-import java.util.UUID;
 
 /**
  * Responsible for composing {@link HtmlEmail}s
@@ -83,6 +85,37 @@ public class EmailComposer {
             LOGGER.error(e.getMessage(), e);
             throw new EmailException(String.format("Failed to compose alert about opportunity %s",
                     opportunity.getCustomer()), e);
+        }
+
+        return email;
+    }
+
+    /**
+     * Composes a new password reset {@link HtmlEmail} to the provided {@link User}
+     *
+     * @param user the user that has requested a password reset
+     * @param url the url that the user will use to reset their password
+     * @return a new {@link HtmlEmail} that is ready to send to the user
+     * @throws EmailException if the recipient couldn't be added, or if the email failed to
+     * render from the internal template
+     */
+    public HtmlEmail composePasswordResetEmail(User user, String url) throws EmailException {
+        HtmlEmail email = new HtmlEmail();
+        email.setHostName(configuration.getHost());
+        email.setSmtpPort(configuration.getPort());
+        email.setFrom(configuration.getFrom());
+        email.setSubject("Password Reset");
+        String recipient = user.getEmail();
+        email.addTo(recipient);
+
+        try {
+            LOGGER.info("Composing password reset email to user {}", recipient);
+            email.setHtmlMsg(renderer.renderEmail(new PasswordResetHtml(url)));
+            email.setTextMsg(renderer.renderEmail(new PasswordResetText(url)));
+        } catch (IOException e) {
+            LOGGER.error(e.getMessage(), e);
+            throw new EmailException(String.format("Failed to compose email addressed to %s",
+                    recipient), e);
         }
 
         return email;

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/email/EmailService.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/email/EmailService.java
@@ -6,6 +6,8 @@ import org.apache.commons.validator.routines.EmailValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.andrewgorton.digitalmarketplace.alerter.Opportunity;
+import uk.andrewgorton.digitalmarketplace.alerter.User;
+import uk.andrewgorton.digitalmarketplace.alerter.resources.UserResource;
 
 import java.util.Arrays;
 
@@ -53,6 +55,25 @@ public class EmailService {
         }
 
         LOGGER.info("Sending email {}", email.getSubject());
+        email.send();
+    }
+
+    /**
+     * Sends an email containing the provided url to the email address of the provided user, allowing them
+     * to reset their password.
+     *
+     * @param user the user to send the password reset email to
+     * @param url the password reset url, construct according to what
+     * {@link UserResource#showResetPasswordView(long, String)} expects
+     * @throws EmailException if the email could not be composed, or if there is no email configuration enabled
+     */
+    public void sendPasswordResetEmail(User user, String url) throws EmailException {
+        if (!configuration.isEnabled()) {
+            throw new EmailException("Email configuration not enabled");
+        }
+
+        HtmlEmail email = composer.composePasswordResetEmail(user, url);
+        LOGGER.info("Sending email {} to {}", email.getSubject(), user.getEmail());
         email.send();
     }
 }

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/exceptions/ForbiddenException.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/exceptions/ForbiddenException.java
@@ -1,7 +1,0 @@
-package uk.andrewgorton.digitalmarketplace.alerter.exceptions;
-
-public class ForbiddenException extends RuntimeException {
-    public ForbiddenException() {
-        super();
-    }
-}

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/mappers/UnauthorizedExceptionMapper.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/mappers/UnauthorizedExceptionMapper.java
@@ -2,12 +2,9 @@ package uk.andrewgorton.digitalmarketplace.alerter.mappers;
 
 import uk.andrewgorton.digitalmarketplace.alerter.exceptions.UnauthorizedException;
 import uk.andrewgorton.digitalmarketplace.alerter.resources.HomepageResource;
-import uk.andrewgorton.digitalmarketplace.alerter.resources.SecurityResource;
-import uk.andrewgorton.digitalmarketplace.alerter.views.exceptions.ForbiddenView;
 import uk.andrewgorton.digitalmarketplace.alerter.views.exceptions.UnauthorizedView;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/resources/HomepageResource.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/resources/HomepageResource.java
@@ -4,10 +4,8 @@ import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.jersey.sessions.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.andrewgorton.digitalmarketplace.alerter.User;
 import uk.andrewgorton.digitalmarketplace.alerter.annotations.LoginRequired;
 import uk.andrewgorton.digitalmarketplace.alerter.dao.UserDAO;
-import uk.andrewgorton.digitalmarketplace.alerter.exceptions.ForbiddenException;
 import uk.andrewgorton.digitalmarketplace.alerter.filters.AdminRequiredFilter;
 import uk.andrewgorton.digitalmarketplace.alerter.views.HomeView;
 

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/resources/OpportunityResource.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/resources/OpportunityResource.java
@@ -9,7 +9,6 @@ import uk.andrewgorton.digitalmarketplace.alerter.dao.OpportunityDAO;
 import uk.andrewgorton.digitalmarketplace.alerter.dao.ResponseDAO;
 import uk.andrewgorton.digitalmarketplace.alerter.email.EmailService;
 import uk.andrewgorton.digitalmarketplace.alerter.Opportunity;
-import uk.andrewgorton.digitalmarketplace.alerter.exceptions.ForbiddenException;
 import uk.andrewgorton.digitalmarketplace.alerter.views.opportunity.DetailView;
 import uk.andrewgorton.digitalmarketplace.alerter.views.opportunity.ListView;
 import uk.andrewgorton.digitalmarketplace.alerter.views.response.ResponseExitView;

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/security/ProtectedPassword.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/security/ProtectedPassword.java
@@ -1,0 +1,34 @@
+package uk.andrewgorton.digitalmarketplace.alerter.security;
+
+/**
+ * Represents a salted and hashed password that is ready to be stored in the database
+ */
+public class ProtectedPassword {
+
+    /**
+     * A random alphanumeric string appended to the password
+     */
+    private String salt;
+    /**
+     * The hashed and salted password
+     */
+    private String password;
+
+    /**
+     * Produces a hashed and salted password
+     *
+     * @param password user password
+     */
+    public ProtectedPassword(String password, String salt) {
+        this.salt = salt;
+        this.password = password;
+    }
+
+    public String getSalt() {
+        return this.salt;
+    }
+
+    public String getProtected() {
+        return this.password;
+    }
+}

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/security/SecurityService.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/security/SecurityService.java
@@ -1,0 +1,53 @@
+package uk.andrewgorton.digitalmarketplace.alerter.security;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import uk.andrewgorton.digitalmarketplace.alerter.User;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Provides security specific services such as hashing and salting to the rest of the application.
+ */
+public class SecurityService {
+
+    /**
+     * Creates a protected password with a randomised salt
+     *
+     * @param password the password to be hashed
+     * @return a new {@link ProtectedPassword}
+     */
+    public ProtectedPassword protectPassword(final String password) {
+        return this.protectPassword(password, RandomStringUtils.randomAlphanumeric(12));
+    }
+    /**
+     * Creates a protected password
+     *
+     * @param password the password to be hashed
+     * @return a new {@link ProtectedPassword}
+     */
+    public ProtectedPassword protectPassword(final String password, final String salt) {
+        return new ProtectedPassword(this.sha256(salt + password), salt);
+    }
+
+    /**
+     * Salts and hashes 'guess' and compares it to the user's password
+     *
+     * @param user the user that to compare passwords with
+     * @param guess the password to compare against
+     * @return <code>true</code> if the passwords match or <code>false</code> if they do not
+     */
+    public boolean verifyPassword(User user, String guess) {
+        return user.getPassword().equals(this.protectPassword(guess, user.getSalt()).getProtected());
+    }
+
+    /**
+     * Hashes the provided string using SHA-256
+     *
+     * @param in the string to produce a has of
+     * @return
+     */
+    public String sha256(String in) {
+        return new String(DigestUtils.sha256(in.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/tasks/SetUserPassword.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/tasks/SetUserPassword.java
@@ -6,18 +6,21 @@ import io.dropwizard.jdbi.DBIFactory;
 import io.dropwizard.setup.Environment;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.skife.jdbi.v2.DBI;
 import uk.andrewgorton.digitalmarketplace.alerter.DigitalMarketplaceAlerterConfiguration;
 import uk.andrewgorton.digitalmarketplace.alerter.dao.UserDAO;
-
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
+import uk.andrewgorton.digitalmarketplace.alerter.security.ProtectedPassword;
+import uk.andrewgorton.digitalmarketplace.alerter.security.SecurityService;
 
 public class SetUserPassword extends EnvironmentCommand<DigitalMarketplaceAlerterConfiguration> {
-    public SetUserPassword(Application<DigitalMarketplaceAlerterConfiguration> application) {
+
+    private final SecurityService securityService;
+
+
+    public SetUserPassword(Application<DigitalMarketplaceAlerterConfiguration> application,
+                           SecurityService securityService) {
         super(application, "setuserpassword", "Sets the user password in the db");
+        this.securityService = securityService;
     }
 
     @Override
@@ -38,24 +41,16 @@ public class SetUserPassword extends EnvironmentCommand<DigitalMarketplaceAlerte
 
     @Override
     protected void run(Environment environment, Namespace namespace, DigitalMarketplaceAlerterConfiguration digitalMarketplaceAlerterConfiguration) throws Exception {
-        String salt = RandomStringUtils.randomAlphanumeric(12);
         String username = namespace.getString("username");
-        String password = namespace.getString("password");
-        String saltedPassword = String.format("%s%s", salt, password);
-        System.out.println(String.format("Salted password: %s", saltedPassword));
-
-        MessageDigest digest = MessageDigest.getInstance("SHA-256");
-        byte[] hash = digest.digest(saltedPassword.getBytes(StandardCharsets.UTF_8));
-        String hexHash = Hex.encodeHexString(hash);
-        System.out.println(String.format("Hash of salted password: %s", hexHash));
+        ProtectedPassword protectedPassword = this.securityService.protectPassword(namespace.getString("password"));
 
         final DBIFactory factory = new DBIFactory();
         final DBI jdbi = factory.build(environment, digitalMarketplaceAlerterConfiguration.getDatabase(), "h2");
         final UserDAO userDAO = jdbi.onDemand(UserDAO.class);
 
-        userDAO.updateUserCredentials(username, salt, hexHash);
+        userDAO.updateUserCredentials(username, protectedPassword.getSalt(), protectedPassword.getProtected());
         userDAO.close();
-        System.out.println("Updated");
+        System.out.println("Password Updated Successfully");
 
         // No idea why I have to do this but if I don't, the process hangs
         System.exit(0);

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/views/email/security/PasswordResetHtml.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/views/email/security/PasswordResetHtml.java
@@ -1,0 +1,20 @@
+package uk.andrewgorton.digitalmarketplace.alerter.views.email.security;
+
+import io.dropwizard.views.View;
+
+/**
+ * Represents an HTML template for a password reset email
+ */
+public class PasswordResetHtml extends View {
+
+    private String url;
+
+    public PasswordResetHtml(String url) {
+        super("email-password-reset-html.ftl");
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/views/email/security/PasswordResetText.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/views/email/security/PasswordResetText.java
@@ -1,0 +1,20 @@
+package uk.andrewgorton.digitalmarketplace.alerter.views.email.security;
+
+import io.dropwizard.views.View;
+
+/**
+ * Represents a text template for a password reset email
+ */
+public class PasswordResetText extends View {
+
+    private String url;
+
+    public PasswordResetText(String url) {
+        super("email-password-reset-text.ftl");
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+}

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/views/security/ForgottenPasswordView.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/views/security/ForgottenPasswordView.java
@@ -1,0 +1,25 @@
+package uk.andrewgorton.digitalmarketplace.alerter.views.security;
+
+import io.dropwizard.views.View;
+
+/**
+ * Created by ross on 28/11/16.
+ */
+public class ForgottenPasswordView extends View {
+
+    private boolean submitted;
+
+
+    public ForgottenPasswordView() {
+        this(false);
+    }
+
+    public ForgottenPasswordView(boolean submitted) {
+        super("forgotten-password-view.ftl");
+        this.submitted = submitted;
+    }
+
+    public boolean isSubmitted() {
+        return submitted;
+    }
+}

--- a/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/views/security/ResetPasswordView.java
+++ b/src/main/java/uk/andrewgorton/digitalmarketplace/alerter/views/security/ResetPasswordView.java
@@ -1,0 +1,13 @@
+package uk.andrewgorton.digitalmarketplace.alerter.views.security;
+
+import io.dropwizard.views.View;
+
+/**
+ * Created by ross on 29/11/16.
+ */
+public class ResetPasswordView extends View {
+
+    public ResetPasswordView() {
+        super("reset-password-view.ftl");
+    }
+}

--- a/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/email/security/email-password-reset-html.ftl
+++ b/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/email/security/email-password-reset-html.ftl
@@ -1,0 +1,11 @@
+<html>
+<head><style>
+body {
+   font-family: Tahoma, Geneva, sans-serif;
+}
+</style></head>
+<body>
+<h1>Reset Password</h1>
+<p>Please <a href="${url}">follow this link</a> to reset your password</p>
+</body>
+</html>

--- a/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/email/security/email-password-reset-text.ftl
+++ b/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/email/security/email-password-reset-text.ftl
@@ -1,0 +1,2 @@
+Please visit the link below to reset your password
+${url}

--- a/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/security/forgotten-password-view.ftl
+++ b/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/security/forgotten-password-view.ftl
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <#include "../fragments/head.ftl" parse="false">
+    <title>Forgotten Password</title>
+</head>
+<body>
+<h1>Change Password</h1>
+<p>To change your password, please enter your email below, a link will be sent to you at this address
+that will allow you to set a new password.</p>
+<form method="post">
+<input type="text" name="email">
+<input type="submit" value="Send">
+</form>
+</body>
+</html>

--- a/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/security/loginview.ftl
+++ b/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/security/loginview.ftl
@@ -28,5 +28,6 @@
     <input type="submit" value="Login">
     </form>
 </body>
+<p><a href="/security/forgotten-password">I've forgotten my password</a></p>
 <#if returnLocation??><p><a href="${returnLocation}">Cancel</a></p></#if>
 </html>

--- a/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/security/reset-password-view.ftl
+++ b/src/main/resources/uk/andrewgorton/digitalmarketplace/alerter/views/security/reset-password-view.ftl
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <#include "../fragments/head.ftl" parse="false">
+    <title>Reset Password</title>
+</head>
+<body>
+<h1>Reset Password</h1>
+<p>Please enter your new password below:</p>
+<form method="post">
+<b>New password </b><input type="text" name="password">
+<br>
+<b>Repeat new password </b><input type="text" name="repeatPassword">
+<input type="submit" value="Submit">
+</form>
+</body>
+</html>

--- a/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/email/EmailComposerTest.java
+++ b/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/email/EmailComposerTest.java
@@ -8,12 +8,15 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.andrewgorton.digitalmarketplace.alerter.Opportunity;
+import uk.andrewgorton.digitalmarketplace.alerter.User;
 import uk.andrewgorton.digitalmarketplace.alerter.views.email.EmailViewRenderer;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -100,4 +103,73 @@ public class EmailComposerTest {
         assertTrue(email.getSubject().contains(customer));
     }
 
+    @Test
+    public void ComposePasswordResetEmail() throws Exception {
+        String host = "host";
+        int port = 1;
+        String from = "nobody@nowhere.com";
+        String htmlContent = "htmlMsg";
+        String textContent = "txtMsg";
+        String responseBaseUrl = "responseUrl";
+        User user = mock(User.class);
+        String recipient = "user@example.com";
+
+        when(configuration.getHost()).thenReturn(host);
+        when(configuration.getPort()).thenReturn(port);
+        when(configuration.getFrom()).thenReturn(from);
+        when(user.getEmail()).thenReturn(recipient);
+        when(renderer.renderEmail(any(View.class)))
+                .thenReturn(htmlContent)
+                .thenReturn(textContent);
+        EmailComposer composer = new EmailComposer(configuration, renderer);
+
+        HtmlEmail email = composer.composePasswordResetEmail(user, responseBaseUrl);
+
+        assertEquals(host, email.getHostName());
+        assertEquals(Integer.toString(port), email.getSmtpPort());
+        assertEquals(from, email.getFromAddress().toString());
+        assertTrue(email.getSubject().equals("Password Reset"));
+        assertEquals(1, email.getToAddresses().size());
+        assertEquals(recipient, email.getToAddresses().get(0).getAddress());
+    }
+
+    @Test(expected = EmailException.class)
+    public void FailToRenderPasswordResetEmail() throws Exception {
+        String host = "host";
+        int port = 1;
+        String from = "nobody@nowhere.com";
+        String customer = "customer";
+        User user = mock(User.class);
+        String responseBaseUrl = "responseUrl";
+        when(user.getEmail()).thenReturn("user@example.com");
+
+        when(configuration.getHost()).thenReturn(host);
+        when(configuration.getPort()).thenReturn(port);
+        when(configuration.getFrom()).thenReturn(from);
+        when(opportunity.getCustomer()).thenReturn(customer);
+        when(renderer.renderEmail(any(View.class)))
+                .thenThrow(new IOException("expected-error"));
+        EmailComposer composer = new EmailComposer(configuration, renderer);
+
+        composer.composePasswordResetEmail(user, responseBaseUrl);
+    }
+
+    @Test(expected = EmailException.class)
+    public void FailToAddRecipientToPasswordResetEmail() throws Exception {
+        String host = "host";
+        int port = 1;
+        String from = "nobody@nowhere.com";
+        String customer = "customer";
+        User user = mock(User.class);
+        String responseBaseUrl = "responseUrl";
+        when(user.getEmail()).thenReturn("invalid email!!");
+
+        when(configuration.getHost()).thenReturn(host);
+        when(configuration.getPort()).thenReturn(port);
+        when(configuration.getFrom()).thenReturn(from);
+        when(opportunity.getCustomer()).thenReturn(customer);
+        EmailComposer composer = new EmailComposer(configuration, renderer);
+
+        composer.composePasswordResetEmail(user, responseBaseUrl);
+    }
 }

--- a/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/email/EmailServiceTest.java
+++ b/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/email/EmailServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.andrewgorton.digitalmarketplace.alerter.Opportunity;
+import uk.andrewgorton.digitalmarketplace.alerter.User;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
@@ -85,6 +86,27 @@ public class EmailServiceTest {
         service.sendBidManagerEmail(opportunity, emails, "");
 
         verify(email, never()).send();
+    }
+
+    @Test
+    public void SendPasswordResetEmail() throws Exception {
+        User user = mock(User.class);
+        String responseUrl = "responseUrl";
+        when(configuration.isEnabled()).thenReturn(true);
+        when(validator.isValid(anyString())).thenReturn(true);
+        when(composer.composePasswordResetEmail(user, responseUrl)).thenReturn(email);
+        EmailService service = new EmailService(composer, configuration, validator);
+
+        service.sendPasswordResetEmail(user, responseUrl);
+
+        verify(email).send();
+    }
+
+    @Test(expected = EmailException.class)
+    public void SendPasswordResetEmailEmailConfigNotEnabled() throws Exception {
+        EmailService service = new EmailService(composer, configuration, validator);
+        service.sendPasswordResetEmail(null, null);
+        verify(composer, never()).composePasswordResetEmail(any(User.class), anyString());
     }
 
 }

--- a/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/resources/SecurityResourceTest.java
+++ b/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/resources/SecurityResourceTest.java
@@ -1,18 +1,35 @@
 package uk.andrewgorton.digitalmarketplace.alerter.resources;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import uk.andrewgorton.digitalmarketplace.alerter.User;
 import uk.andrewgorton.digitalmarketplace.alerter.dao.UserDAO;
+import uk.andrewgorton.digitalmarketplace.alerter.email.EmailService;
+import uk.andrewgorton.digitalmarketplace.alerter.security.SecurityService;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
+/**
+ * Tests for {@link SecurityResource}
+ */
+@RunWith(MockitoJUnitRunner.class)
 public class SecurityResourceTest {
 
+    @Mock
+    public UserDAO userDAO;
+    @Mock
+    public SecurityService securityService;
 
     @Test
     public void HandleLoginXForwardedRedirctToHome() throws Exception {
@@ -28,12 +45,11 @@ public class SecurityResourceTest {
         UserDAO dao = mock(UserDAO.class);
         User user = mock(User.class);
         when(user.isDisabled()).thenReturn(false);
-        when(user.getSalt()).thenReturn("salt");
-        when(user.getPassword()).thenReturn("9c95bf909cf17beaa7a4c71d86671566294699a994db7aaa8ffea004f425954f");
         when(user.getUsername()).thenReturn(username);
         when(user.getId()).thenReturn(userId);
         when(dao.findByUsername(username)).thenReturn(user);
-        SecurityResource resource = new SecurityResource(dao);
+        when(securityService.verifyPassword(user, password)).thenReturn(true);
+        SecurityResource resource = new SecurityResource(dao, null, securityService);
 
         // mock method parameters
         when(request.getHeader("X-Forwarded-For")).thenReturn("1.2.3.4");
@@ -64,12 +80,11 @@ public class SecurityResourceTest {
         UserDAO dao = mock(UserDAO.class);
         User user = mock(User.class);
         when(user.isDisabled()).thenReturn(false);
-        when(user.getSalt()).thenReturn("salt");
-        when(user.getPassword()).thenReturn("9c95bf909cf17beaa7a4c71d86671566294699a994db7aaa8ffea004f425954f");
         when(user.getUsername()).thenReturn(username);
         when(user.getId()).thenReturn(userId);
         when(dao.findByUsername(username)).thenReturn(user);
-        SecurityResource resource = new SecurityResource(dao);
+        when(securityService.verifyPassword(user, password)).thenReturn(true);
+        SecurityResource resource = new SecurityResource(dao, null, securityService);
 
         // difficult to assert anything on the response
         resource.handleLogin(session, request, info, returnLocation, username, password);
@@ -79,28 +94,51 @@ public class SecurityResourceTest {
         verify(session).setAttribute("authenticated", true);
     }
     
-    @Test
+    @Test(expected = ForbiddenException.class)
     public void HandleLoginEmptyUsername() throws Exception {
-        HttpSession session = mock(HttpSession.class);
-        HttpServletRequest request = mock(HttpServletRequest.class);
+        new SecurityResource(userDAO, null, null)
+                .handleLogin(null, null, null, null, "", null);
+    }
+
+    @Test
+    public void VerifyUserAndSendPasswordResetEmail() throws Exception {
         UriInfo info = mock(UriInfo.class, RETURNS_DEEP_STUBS);
-        String returnLocation = "";
-        String username = "";
-        String password = "";
+        long id = 1;
+        String email = "user@example.com";
+        String url = "path/to/password/reset/page";
+        EmailService emailService = mock(EmailService.class);
+        UserDAO userDAO = mock(UserDAO.class);
+        User user = mock(User.class);
 
-        when(request.getRemoteHost()).thenReturn("remote-host");
+        when(userDAO.findByEmail(email)).thenReturn(user);
+        when(user.getEmail()).thenReturn(email);
+        when(user.getId()).thenReturn(id);
         when(info.getBaseUriBuilder()
-                .path(SecurityResource.class)
-                .path("/login")
-                .queryParam("returnLocation", returnLocation)
+                .path(any(Class.class))
+                .path(anyString())
+                .path(anyString())
+                .path(anyString())
                 .build())
-                .thenReturn(URI.create("test"));
+                .thenReturn(URI.create(url));
 
-        new SecurityResource(null)
-                .handleLogin(session, request, info, returnLocation, username, password);
+        Response response = new SecurityResource(userDAO, emailService, null)
+                .verifyUserAndSendPasswordResetEmail(info, email);
 
-        verify(session).setAttribute("username", username);
-        verify(session).setAttribute("authenticated", false);
+        verify(emailService).sendPasswordResetEmail(user, url);
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertTrue(response.getEntity().toString().contains(email));
+    }
+
+    @Test
+    public void VerifyUserNotFound() throws Exception {
+        String email = "";
+        UserDAO userDAO = mock(UserDAO.class);
+
+        Response response = new SecurityResource(userDAO, null, null)
+                .verifyUserAndSendPasswordResetEmail(null, email);
+
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+        verify(userDAO, never()).insertKey(anyLong(), anyString());
     }
 
 }

--- a/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/security/SecurityServiceTest.java
+++ b/src/test/java/uk/andrewgorton/digitalmarketplace/alerter/security/SecurityServiceTest.java
@@ -1,0 +1,68 @@
+package uk.andrewgorton.digitalmarketplace.alerter.security;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.andrewgorton.digitalmarketplace.alerter.User;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link SecurityService}
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SecurityServiceTest {
+
+
+    @Test
+    public void protectPassword() throws Exception {
+        String pass = "pass";
+        String salt = "salt";
+        SecurityService securityService = spy(SecurityService.class);
+        doReturn(pass).when(securityService).sha256(salt + pass);
+
+        ProtectedPassword actual = securityService.protectPassword(pass, salt);
+
+        assertEquals(pass, actual.getProtected());
+        assertEquals(salt, actual.getSalt());
+    }
+
+    @Test
+    public void verifyPassword() throws Exception {
+        String guess = "guess";
+        String salt = "salt";
+        String password = "Ae)ikas908asdi90uajgf";
+        User user = mock(User.class);
+        when(user.getSalt()).thenReturn("salt");
+        when(user.getPassword()).thenReturn(password);
+        SecurityService securityService = spy(new SecurityService());
+        ProtectedPassword protectedPassword = mock(ProtectedPassword.class);
+        when(protectedPassword.getProtected()).thenReturn(password);
+        doReturn(protectedPassword).when(securityService).protectPassword(guess, salt);
+
+        boolean result = securityService.verifyPassword(user, guess);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void verifyPasswordRejected() throws Exception {
+        String guess = "guess";
+        String salt = "salt";
+        User user = mock(User.class);
+        when(user.getSalt()).thenReturn("salt");
+        when(user.getPassword()).thenReturn("user-password");
+        SecurityService securityService = spy(new SecurityService());
+        ProtectedPassword protectedPassword = mock(ProtectedPassword.class);
+        when(protectedPassword.getProtected()).thenReturn("hashed-guess");
+        doReturn(protectedPassword).when(securityService).protectPassword(guess, salt);
+
+        boolean result = securityService.verifyPassword(user, guess);
+
+        assertFalse(result);
+    }
+
+}


### PR DESCRIPTION
- Remove custom ForbiddenException as the default jax-rs is a RuntimeException and will suffice.
- Add an "i've forgotten my password" option to allow users to reset their password
- Add email templates to allow a password reset email to be sent to a user
- Add user resource endpoints (with session key) as link for email, allowing user to change their password
- Unit tests

Tested this locally on my system